### PR TITLE
Add Valla DNS to DNS Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ DNS is a core internet protocol that translates human-readable domain names into
 - **[DNS Inspect](https://dnsinspect.com/)** - A free web tool that checks your domain's servers for common DNS and mail errors and generates a report explaining how to fix them.
 - **[dnssec](https://github.com/themalwarenews/dnssec)** - Performs DNS security audits and takes a DNS IP as user input, which could act as a DNS security scanner.
 - **[EDUdig](https://edudig.se/)** - Web based DNS troubleshooting tool
+- **[Valla DNS](https://valladns.com)** - Free web toolkit for DNS, WHOIS, SSL and email-authentication (SPF/DKIM/DMARC/blacklist) checks with a global propagation map.
     
 ---
 


### PR DESCRIPTION
Adds [Valla DNS](https://valladns.com) to the DNS Tools section. It is a free web toolkit that includes email-authentication checks (SPF/DKIM/DMARC), DNS blacklist/URIBL lookups, WHOIS, and SSL/TLS grading alongside DNS and global propagation, so it fits the DNS-security focus of this list. Thanks for maintaining this!